### PR TITLE
Update Gemfile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,12 +2,13 @@
 
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 4.0'
+gem 'jekyll', '~> 4.3'
 
 group :jekyll_plugins do
   gem "jekyll-remote-theme"
   gem "jekyll-sitemap"
   gem "jekyll-feed"
   gem "jekyll-redirect-from"
+  gem "jekyll-sass-converter", "~> 2.0"
 end
 gem "webrick", "~> 1.7"


### PR DESCRIPTION
`docker-compose up` fails because of an issue with the `jekyll-sass-converter` gem.

I've run into this a couple of time on other installs of Jekyll recently; the fix is to add that to the gem file and lock the version number to 2.0+.