### PR TITLE
Reduce iterations to two

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - FLASK_ENV=development
       - BROKER_URL=redis://redis:6379/0
       - BACKEND_URL=redis://redis:6379/0
+      - ITERATIONS=2
     depends_on:
       - app
       - redis

--- a/mentor_match_infra/mentor_match_infra/mentor_match_stack.py
+++ b/mentor_match_infra/mentor_match_infra/mentor_match_stack.py
@@ -87,6 +87,7 @@ class MentorMatchWebStack(cdk.Stack):
         construct_id: str,
         image_tag: str = "latest",
         debug: bool = False,
+        iterations: int = 2,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -139,7 +140,7 @@ class MentorMatchWebStack(cdk.Stack):
                 f"ghcr.io/mentor-matching-online/mentor-match/worker:{image_tag}"
             ),
             container_name="worker",
-            environment=broker_vars,
+            environment={**broker_vars, "ITERATIONS": str(iterations)},
             logging=ecs.AwsLogDriver(
                 stream_prefix="celery", mode=ecs.AwsLogDriverMode.NON_BLOCKING
             ),

--- a/mentor_match_web/app/tasks/tasks.py
+++ b/mentor_match_web/app/tasks/tasks.py
@@ -25,7 +25,8 @@ def async_process_data(
     mentees,
     unmatched_bonus: int = 6,
 ) -> Tuple[List[CSMentor], List[CSMentee], int]:
-    all_rules = [base_rules() for _ in range(3)]
+    iterations = int(os.environ.get("ITERATIONS", 3))
+    all_rules = [base_rules() for _ in range(iterations)]
     for ruleset in all_rules:
         ruleset.append(UnmatchedBonus(unmatched_bonus))
     matched_mentors, matched_mentees = process.process_data(


### PR DESCRIPTION
I've done my best to make this flexible by passing the number of iterations as an environment variable. That means that, if we want to deploy this code for anyone else, we can create a new `Stack` object with a different number of iterations
![Screenshot 2023-11-08 at 17 28 32](https://github.com/mentor-matching-online/mentor-match/assets/3410350/ea3552fe-a49e-488d-acfa-b0798150b13b)


I would also point out that, if users only want two iterations instead of the usual three, they could simply...not use the last set.
